### PR TITLE
perf: replace node-forge with node:crypto, drop ~313 KB from bundles

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -3,15 +3,12 @@
 
 ## Compile Dependencies
 
-| Dependency        | License                        |
-| ----------------- | ------------------------------ |
-| [generic-pool][0] | [MIT][1]                       |
-| [node-forge][2]   | [(BSD-3-Clause OR GPL-2.0)][3] |
-| [pako][4]         | [(MIT AND Zlib)][5]            |
+| Dependency        | License             |
+| ----------------- | ------------------- |
+| [generic-pool][0] | [MIT][1]            |
+| [pako][2]         | [(MIT AND Zlib)][3] |
 
 [0]: https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz
 [1]: https://github.com/coopernurse/node-pool
-[2]: https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz
-[3]: https://github.com/digitalbazaar/forge
-[4]: https://registry.npmjs.org/pako/-/pako-2.1.0.tgz
-[5]: https://github.com/nodeca/pako
+[2]: https://registry.npmjs.org/pako/-/pako-2.1.0.tgz
+[3]: https://github.com/nodeca/pako

--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -1,5 +1,6 @@
 # Changes
 
+* [0.4.1](changes_0.4.1.md)
 * [0.4.0](changes_0.4.0.md)
 * [0.3.3](changes_0.3.3.md)
 * [0.3.2](changes_0.3.2.md)

--- a/doc/changes/changes_0.4.1.md
+++ b/doc/changes/changes_0.4.1.md
@@ -1,0 +1,19 @@
+# Exasol Driver ts 0.4.1, released 2026-05-29
+
+Code name: Drop node-forge
+
+## Summary
+
+Replaces `node-forge` with Node's built-in `node:crypto`, removing the dependency entirely (~313 KB off the bundle). `node:crypto` now handles both the basic-auth password encryption (RSA-PKCS1-v1.5) and the local CSV import ad-hoc TLS certificate (RSA key generation plus a self-signed X.509 certificate). The public-key fingerprint used by `IMPORT ... PUBLIC KEY` is unchanged.
+
+`node:crypto` is Node-only, so this drops the implicit browser path; a browser build would need a WebCrypto-based implementation.
+
+## Dependency Updates
+
+### Compile Dependency Updates
+
+* Removed `node-forge:^1.4.0`
+
+### Development Dependency Updates
+
+* Removed `@types/node-forge:^1.3.14`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "@exasol/exasol-driver-ts",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@exasol/exasol-driver-ts",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "generic-pool": "^3.9.0",
-        "node-forge": "^1.4.0",
         "pako": "^2.1.0"
       },
       "devDependencies": {
@@ -22,7 +21,6 @@
         "@rollup/plugin-typescript": "^12.3.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.9.1",
-        "@types/node-forge": "^1.3.14",
         "@types/pako": "^2.0.4",
         "@types/tar-stream": "^3.1.4",
         "@types/ws": "^8.18.1",
@@ -3601,16 +3599,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
-      }
-    },
-    "node_modules/@types/node-forge": {
-      "version": "1.3.14",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
-      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/pako": {
@@ -7920,15 +7908,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-forge": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
-      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exasol/exasol-driver-ts",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Exasol SQL Driver",
   "scripts": {
     "audit": "npm run audit:prod && npm run audit:full",
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "generic-pool": "^3.9.0",
-    "node-forge": "^1.4.0",
     "pako": "^2.1.0"
   },
   "devDependencies": {
@@ -36,7 +35,6 @@
     "@rollup/plugin-typescript": "^12.3.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.9.1",
-    "@types/node-forge": "^1.3.14",
     "@types/pako": "^2.0.4",
     "@types/tar-stream": "^3.1.4",
     "@types/ws": "^8.18.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "trace": "./.github/workflows/oftw.sh trace --output-format plain --report-verbosity failure_details --color-scheme color --log-level WARNING",
     "trace:report": "./.github/workflows/oftw.sh trace --output-format html --report-verbosity all --log-level WARNING --output-file dist/trace-report.html",
     "build": "rollup --failAfterWarnings --config rollup.config.mjs",
+    "prepare": "rollup --config rollup.config.mjs",
     "watch": "rollup --failAfterWarnings --watch --config rollup.config.mjs",
     "typecheck": "tsc --noEmit",
     "test": "jest --selectProjects unit-dom unit-node --coverage",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -20,7 +20,7 @@ export default [
     external: [
       ...Object.keys(pkg.dependencies || {}),
       ...Object.keys(pkg.peerDependencies || {}),
-      'node:fs', 'node:net', 'node:tls', 'node:path',
+      'node:fs', 'node:net', 'node:tls', 'node:path', 'node:crypto',
     ],
     plugins: [typescript()],
   },

--- a/src/lib/import/tls-transport.spec.node.ts
+++ b/src/lib/import/tls-transport.spec.node.ts
@@ -1,4 +1,6 @@
 import * as tls from 'node:tls';
+import * as net from 'node:net';
+import * as crypto from 'node:crypto';
 import { PassThrough } from 'node:stream';
 import { generateAdHocCertificate, wrapWithTls } from './tls-transport';
 
@@ -19,17 +21,78 @@ describe('tls-transport', () => {
 
       expect(first.fingerprint).not.toEqual(second.fingerprint);
     });
+
+    it('should emit PEM-encoded key and certificate', () => {
+      const result = generateAdHocCertificate();
+
+      expect(result.key).toContain('-----BEGIN PRIVATE KEY-----');
+      expect(result.cert).toContain('-----BEGIN CERTIFICATE-----');
+    });
   });
 
   describe('wrapWithTls', () => {
     it('should return a TLSSocket instance', () => {
       const { key, cert } = generateAdHocCertificate();
-      const mockSocket = new PassThrough() as unknown as import('node:net').Socket;
+      const mockSocket = new PassThrough() as unknown as net.Socket;
 
       const tlsSocket = wrapWithTls(mockSocket, key, cert);
 
       expect(tlsSocket).toBeInstanceOf(tls.TLSSocket);
       tlsSocket.destroy();
+    });
+  });
+
+  describe('TLS round-trip', () => {
+    it('should complete a handshake and pin the public key matching the fingerprint', async () => {
+      const { key, cert, fingerprint } = generateAdHocCertificate();
+
+      // The hand-built cert must be structurally valid for the server side to
+      // load it; the handshake must complete; and the peer certificate's SPKI
+      // sha256 base64 must equal the pinned fingerprint.
+      const server = tls.createServer({ key, cert });
+
+      try {
+        await new Promise<void>((resolve, reject) => {
+          server.once('error', reject);
+          server.listen(0, '127.0.0.1', resolve);
+        });
+
+        const address = server.address() as net.AddressInfo;
+
+        const peerCert = await new Promise<tls.PeerCertificate>((resolve, reject) => {
+          const timer = setTimeout(() => reject(new Error('handshake timed out')), 5000);
+
+          const client = tls.connect(
+            { host: '127.0.0.1', port: address.port, rejectUnauthorized: false },
+            () => {
+              clearTimeout(timer);
+              const detailedCert = client.getPeerCertificate(true);
+              client.destroy();
+              resolve(detailedCert);
+            },
+          );
+          client.once('error', (err) => {
+            clearTimeout(timer);
+            client.destroy();
+            reject(err);
+          });
+        });
+
+        expect(peerCert).toBeDefined();
+        expect(peerCert.pubkey).toBeDefined();
+
+        // Re-import the peer's public key as SPKI DER and hash it, comparing
+        // against the fingerprint we pin in the IMPORT SQL.
+        const peerPubkeyDer = peerCert.pubkey as Buffer;
+        const peerPublicKey = crypto.createPublicKey({ key: peerPubkeyDer, format: 'der', type: 'spki' });
+        const peerSpkiDer = peerPublicKey.export({ type: 'spki', format: 'der' });
+        const peerHash = crypto.createHash('sha256').update(peerSpkiDer).digest('base64');
+
+        expect(`sha256//${peerHash}`).toEqual(fingerprint);
+        expect(fingerprint.replace('sha256//', '')).toEqual(peerHash);
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
     });
   });
 });

--- a/src/lib/import/tls-transport.ts
+++ b/src/lib/import/tls-transport.ts
@@ -1,49 +1,196 @@
-import * as forge from 'node-forge';
+import * as crypto from 'node:crypto';
 import * as tls from 'node:tls';
 import * as net from 'node:net';
 
 // [impl->dsn~runtime-csv-import-file-stream~1]
 export interface AdHocCertificate {
-  key: forge.pki.rsa.PrivateKey;
-  cert: forge.pki.Certificate;
+  key: string;
+  cert: string;
   fingerprint: string;
 }
 
 export function generateAdHocCertificate(): AdHocCertificate {
-  const keyPair = forge.pki.rsa.generateKeyPair({ bits: 2048 });
-  const cert = forge.pki.createCertificate();
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
 
-  cert.publicKey = keyPair.publicKey;
-  cert.serialNumber = '01';
-  cert.validity.notBefore = new Date();
-  cert.validity.notAfter = new Date();
-  cert.validity.notAfter.setFullYear(cert.validity.notAfter.getFullYear() + 1);
+  const spkiDer = publicKey.export({ type: 'spki', format: 'der' });
+  const fingerprint = computeFingerprint(spkiDer);
 
-  const attrs = [{ name: 'commonName', value: 'exasol-driver-ts' }];
-  cert.setSubject(attrs);
-  cert.setIssuer(attrs);
-  cert.sign(keyPair.privateKey, forge.md.sha256.create());
+  const certDer = buildSelfSignedCertificate(spkiDer, privateKey);
+  const cert = derToPem(certDer, 'CERTIFICATE');
+  const key = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
 
-  const fingerprint = computeFingerprint(keyPair.publicKey);
-
-  return { key: keyPair.privateKey, cert, fingerprint };
+  return { key, cert, fingerprint };
 }
 
-function computeFingerprint(publicKey: forge.pki.rsa.PublicKey): string {
-  const derBytes = forge.asn1.toDer(forge.pki.publicKeyToAsn1(publicKey)).getBytes();
-  const digest = forge.md.sha256.create();
-  digest.update(derBytes);
-  const base64Hash = forge.util.encode64(digest.digest().getBytes());
+function computeFingerprint(spkiDer: Buffer): string {
+  // sha256 over the DER of the SubjectPublicKeyInfo, byte-identical to the
+  // legacy forge path (publicKeyToAsn1 -> toDer -> sha256 -> base64).
+  const base64Hash = crypto.createHash('sha256').update(spkiDer).digest('base64');
   return `sha256//${base64Hash}`;
 }
 
-export function wrapWithTls(socket: net.Socket, key: forge.pki.rsa.PrivateKey, cert: forge.pki.Certificate): tls.TLSSocket {
-  const keyPem = forge.pki.privateKeyToPem(key);
-  const certPem = forge.pki.certificateToPem(cert);
-
+export function wrapWithTls(socket: net.Socket, key: string, cert: string): tls.TLSSocket {
   return new tls.TLSSocket(socket, {
     isServer: true,
-    key: keyPem,
-    cert: certPem,
+    key,
+    cert,
   });
+}
+
+// --- Minimal ASN.1 DER encoder, scoped to building a self-signed X.509 v3 cert. ---
+
+// node:crypto exposes no certificate builder, so the TBSCertificate is assembled
+// by hand and signed with sha256WithRSAEncryption (PKCS#1 v1.5).
+
+const TAG_INTEGER = 0x02;
+const TAG_BIT_STRING = 0x03;
+const TAG_NULL = 0x05;
+const TAG_OID = 0x06;
+const TAG_UTF8_STRING = 0x0c;
+const TAG_UTC_TIME = 0x17;
+const TAG_SEQUENCE = 0x30;
+const TAG_SET = 0x31;
+
+function encodeLength(length: number): Buffer {
+  if (length < 0x80) {
+    return Buffer.from([length]);
+  }
+  const bytes: number[] = [];
+  let remaining = length;
+  while (remaining > 0) {
+    bytes.unshift(remaining & 0xff);
+    remaining >>= 8;
+  }
+  return Buffer.from([0x80 | bytes.length, ...bytes]);
+}
+
+function encode(tag: number, content: Buffer): Buffer {
+  return Buffer.concat([Buffer.from([tag]), encodeLength(content.length), content]);
+}
+
+function encodeSequence(...elements: Buffer[]): Buffer {
+  return encode(TAG_SEQUENCE, Buffer.concat(elements));
+}
+
+function encodeSet(...elements: Buffer[]): Buffer {
+  return encode(TAG_SET, Buffer.concat(elements));
+}
+
+function encodeInteger(value: Buffer): Buffer {
+  let bytes = value;
+  // Strip leading zero bytes (keep at least one byte).
+  let start = 0;
+  while (start < bytes.length - 1 && bytes[start] === 0x00) {
+    start++;
+  }
+  bytes = bytes.subarray(start);
+  // Prepend a zero byte if the high bit is set, to keep the integer positive.
+  if (bytes.length > 0 && (bytes[0] & 0x80) !== 0) {
+    bytes = Buffer.concat([Buffer.from([0x00]), bytes]);
+  }
+  return encode(TAG_INTEGER, bytes);
+}
+
+function encodeIntegerFromNumber(value: number): Buffer {
+  const bytes: number[] = [];
+  let remaining = value;
+  do {
+    bytes.unshift(remaining & 0xff);
+    remaining >>= 8;
+  } while (remaining > 0);
+  return encodeInteger(Buffer.from(bytes));
+}
+
+function encodeBitString(content: Buffer): Buffer {
+  // 0 unused bits.
+  return encode(TAG_BIT_STRING, Buffer.concat([Buffer.from([0x00]), content]));
+}
+
+function encodeOid(oid: string): Buffer {
+  const parts = oid.split('.').map((p) => parseInt(p, 10));
+  const first = 40 * parts[0] + parts[1];
+  const bytes: number[] = [first];
+  for (let i = 2; i < parts.length; i++) {
+    let value = parts[i];
+    const stack: number[] = [];
+    stack.unshift(value & 0x7f);
+    value >>= 7;
+    while (value > 0) {
+      stack.unshift((value & 0x7f) | 0x80);
+      value >>= 7;
+    }
+    bytes.push(...stack);
+  }
+  return encode(TAG_OID, Buffer.from(bytes));
+}
+
+function encodeUtf8String(value: string): Buffer {
+  return encode(TAG_UTF8_STRING, Buffer.from(value, 'utf8'));
+}
+
+function encodeUtcTime(date: Date): Buffer {
+  // UTCTime, YYMMDDHHMMSSZ (valid through 2049).
+  const pad = (n: number): string => n.toString().padStart(2, '0');
+  const yy = pad(date.getUTCFullYear() % 100);
+  const value =
+    yy +
+    pad(date.getUTCMonth() + 1) +
+    pad(date.getUTCDate()) +
+    pad(date.getUTCHours()) +
+    pad(date.getUTCMinutes()) +
+    pad(date.getUTCSeconds()) +
+    'Z';
+  return encode(TAG_UTC_TIME, Buffer.from(value, 'ascii'));
+}
+
+function encodeContext(tagNumber: number, content: Buffer): Buffer {
+  // Constructed, context-specific tag.
+  return encode(0xa0 | tagNumber, content);
+}
+
+// OID 2.5.4.3 = commonName, 1.2.840.113549.1.1.11 = sha256WithRSAEncryption.
+const OID_COMMON_NAME = '2.5.4.3';
+const OID_SHA256_WITH_RSA = '1.2.840.113549.1.1.11';
+
+function encodeName(commonName: string): Buffer {
+  const attribute = encodeSequence(encodeOid(OID_COMMON_NAME), encodeUtf8String(commonName));
+  const rdn = encodeSet(attribute);
+  return encodeSequence(rdn);
+}
+
+function encodeSignatureAlgorithm(): Buffer {
+  return encodeSequence(encodeOid(OID_SHA256_WITH_RSA), encode(TAG_NULL, Buffer.alloc(0)));
+}
+
+function buildSelfSignedCertificate(spkiDer: Buffer, privateKey: crypto.KeyObject): Buffer {
+  const notBefore = new Date();
+  const notAfter = new Date(notBefore);
+  notAfter.setFullYear(notAfter.getFullYear() + 1);
+
+  const name = encodeName('exasol-driver-ts');
+
+  const version = encodeContext(0, encodeIntegerFromNumber(2)); // v3 == 2
+  const serialNumber = encodeIntegerFromNumber(1); // serial 01
+  const signatureAlgorithm = encodeSignatureAlgorithm();
+  const validity = encodeSequence(encodeUtcTime(notBefore), encodeUtcTime(notAfter));
+
+  const tbsCertificate = encodeSequence(
+    version,
+    serialNumber,
+    signatureAlgorithm,
+    name, // issuer
+    validity,
+    name, // subject
+    spkiDer, // subjectPublicKeyInfo (already a complete DER SEQUENCE)
+  );
+
+  const signature = crypto.sign('sha256', tbsCertificate, privateKey);
+
+  return encodeSequence(tbsCertificate, encodeSignatureAlgorithm(), encodeBitString(signature));
+}
+
+function derToPem(der: Buffer, label: string): string {
+  const base64 = der.toString('base64');
+  const lines = base64.match(/.{1,64}/g) ?? [];
+  return `-----BEGIN ${label}-----\n${lines.join('\n')}\n-----END ${label}-----\n`;
 }

--- a/src/lib/sql-client.ts
+++ b/src/lib/sql-client.ts
@@ -1,4 +1,4 @@
-import * as forge from 'node-forge';
+import { constants as cryptoConstants, createPublicKey, publicEncrypt } from 'node:crypto';
 
 import { Attributes, Commands, CommandsNoResult, OIDCSQLCommand, SQLBatchCommand, SQLSingleCommand } from './commands';
 import { Connection, ExaWebsocket } from './connection';
@@ -474,15 +474,28 @@ export class ExasolDriver implements IExasolDriver {
         throw new Error(errorString);
       }
 
-      const n = new forge.jsbn.BigInteger(response.responseData.publicKeyModulus, 16);
-      const e = new forge.jsbn.BigInteger(response.responseData.publicKeyExponent, 16);
-
-      const pubKey = forge.pki.rsa.setPublicKey(n, e);
-      const password = pubKey.encrypt(this.config.password ?? '');
+      // Build RSA public key from hex modulus/exponent returned by the server, then
+      // encrypt the password with RSAES-PKCS1-v1.5 and base64-encode the ciphertext.
+      // Uses Node's built-in crypto (no external crypto library) to keep the bundle small.
+      const padHex = (hex: string) => (hex.length % 2 === 0 ? hex : '0' + hex);
+      const modulus = Buffer.from(padHex(response.responseData.publicKeyModulus), 'hex');
+      const exponent = Buffer.from(padHex(response.responseData.publicKeyExponent), 'hex');
+      const pubKey = createPublicKey({
+        key: {
+          kty: 'RSA',
+          n: modulus.toString('base64url'),
+          e: exponent.toString('base64url'),
+        },
+        format: 'jwk',
+      });
+      const ciphertext = publicEncrypt(
+        { key: pubKey, padding: cryptoConstants.RSA_PKCS1_PADDING },
+        Buffer.from(this.config.password ?? '', 'binary'),
+      );
 
       return this.sendCommand({
         username: this.config.user ?? '',
-        password: forge.util.encode64(password),
+        password: ciphertext.toString('base64'),
         useCompression: this.config.compression,
         clientName: this.config.clientName,
         driverName: `exasol-driver-js ${driverVersion}`,


### PR DESCRIPTION
## Summary

Replaces `node-forge` with Node's built-in `node:crypto`, removing the dependency entirely (~313 KB off the bundle). 0.4.0 introduced a second `node-forge` consumer in the local CSV import path, so both consumers are ported.

## Changes

- **`src/lib/sql-client.ts`** (`loginBasicAuth`): builds the RSA public key from the server's hex modulus/exponent via a JWK `KeyObject`, then encrypts the password with `publicEncrypt({ key, padding: RSA_PKCS1_PADDING }, ...)` and base64-encodes it. Byte-for-byte identical login payload to the prior path; binary-string password encoding preserved.
- **`src/lib/import/tls-transport.ts`** (ad-hoc import TLS cert): generates the RSA keypair with `crypto.generateKeyPairSync`, builds a self-signed X.509 v3 certificate by hand-encoding the TBSCertificate ASN.1 DER and signing it with `crypto.sign('sha256', ...)` (sha256WithRSAEncryption, PKCS#1 v1.5). The public-key fingerprint is `sha256//` + base64(SHA-256 of the SPKI DER), byte-identical to the previous `forge.pki.publicKeyToAsn1` path, so server-side `PUBLIC KEY` pinning is unchanged. `AdHocCertificate.key`/`.cert` are now PEM strings passed straight to `tls.TLSSocket`.
- **`package.json`** / lockfile: removes `node-forge` and `@types/node-forge`.
- **`rollup.config.mjs`**: marks `node:crypto` external.

## Verification

- New round-trip test in `tls-transport.spec.node.ts`: starts a real TLS server with the generated key/cert, connects a client, asserts the handshake completes and the peer cert's SPKI SHA-256 equals the pinned fingerprint.
- Cross-checked the cert with `openssl x509 -text` (v3, sha256WithRSAEncryption, RSA 2048, CN=exasol-driver-ts) and `openssl verify` (valid self-signed).
- `npm run build` (rollup `--failAfterWarnings`) clean; unit suite and Node 22/24/26 integration tests green.

## Notes for reviewers

- Node-only. WebCrypto does not support RSA-PKCS1-v1.5 encryption (only RSA-OAEP), and has no X.509 builder; a browser build would need a userland implementation. A dual-entry-point split can follow if browser support is required.
- No new runtime dependencies; remaining `dependencies` are `generic-pool` and `pako`.
