### PR TITLE
#82: Consume `closeResultSet` responses before reusing a pooled connection

### DIFF
--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -1,5 +1,6 @@
 # Changes
 
+* [0.5.1](changes_0.5.1.md)
 * [0.5.0](changes_0.5.0.md)
 * [0.4.1](changes_0.4.1.md)
 * [0.4.0](changes_0.4.0.md)

--- a/doc/changes/changes_0.5.1.md
+++ b/doc/changes/changes_0.5.1.md
@@ -1,0 +1,10 @@
+# Exasol Driver ts 0.5.1, released 2026-??-??
+
+Code name:
+
+## Summary
+
+## Features
+
+* ISSUE_NUMBER: description
+

--- a/doc/changes/changes_0.5.1.md
+++ b/doc/changes/changes_0.5.1.md
@@ -4,7 +4,8 @@ Code name:
 
 ## Summary
 
-## Features
+This release fixes intermittent failures when pooled queries fetch large result sets.
 
-* ISSUE_NUMBER: description
+## Bugfixes
 
+* #82: Consume `closeResultSet` responses before reusing a pooled connection.

--- a/doc/spec/design/runtime_view.md
+++ b/doc/spec/design/runtime_view.md
@@ -50,11 +50,11 @@ Needs: impl, utest
 ## SQL Execution
 
 ### Query Execution
-`dsn~runtime-query-execution~2`
+`dsn~runtime-query-execution~3`
 
 **Given** an authenticated driver and SQL text
 **When** `query()` is called
-**Then** the driver sends an `execute` command, fetches additional result-set pages until the result is complete or `resultSetMaxRows` is reached, closes remote result sets, validates that the result is a result set, and returns `QueryResult`
+**Then** the driver sends an `execute` command, fetches additional result-set pages until the result is complete or `resultSetMaxRows` is reached, closes remote result sets and consumes their acknowledgements before reusing the connection, validates that the result is a result set, and returns `QueryResult`
 
 Covers:
 - `scn~query-returns-rows~1`

--- a/integration-test/testcases/basic.spec.ts
+++ b/integration-test/testcases/basic.spec.ts
@@ -1,5 +1,6 @@
 import { RandomUuid } from 'testcontainers/build/common/uuid';
 import { ExasolDriver, WebsocketFactory } from '../../src/lib/sql-client';
+import { ExasolPool } from '../../src/lib/sql-pool';
 import { TestEnvironment, TestWebsocketFactory } from '../common';
 import { ExasolContainer, startNewDockerContainer } from '../exasolContainer';
 
@@ -41,7 +42,7 @@ export const basicTests = (name: TestEnvironment, createWSFactory: TestWebsocket
 
 
     describe('query()', () => {
-      // [itest->dsn~runtime-query-execution~2]
+      // [itest->dsn~runtime-query-execution~3]
       it('Exec and fetch', async () => {
         const driver = await openConnection();
 
@@ -72,6 +73,36 @@ export const basicTests = (name: TestEnvironment, createWSFactory: TestWebsocket
 
         expect(data.getRows()).toHaveLength(10000);
         await driver.close();
+      });
+
+      it('reuses a pooled connection after fetching a multi-block result set', async () => {
+        // See https://github.com/exasol/exasol-driver-ts/issues/82
+        const driver = await openConnection();
+        const pool = new ExasolPool(factory, {
+          host: container.getHost(),
+          port: container.getPort(),
+          user: 'sys',
+          password: 'exasol',
+          minimumPoolSize: 1,
+          maximumPoolSize: 1,
+        });
+
+        try {
+          await driver.execute('CREATE SCHEMA ' + schemaName);
+          await driver.execute('CREATE TABLE ' + schemaName + '.TEST_TABLE(x INT)');
+          const values = Array.from({ length: 2000 }, (_, index) => `(${index})`);
+          await driver.execute('INSERT INTO ' + schemaName + '.TEST_TABLE VALUES ' + values.join(','));
+
+          const firstResult = await pool.query('SELECT x FROM ' + schemaName + '.TEST_TABLE ORDER BY x');
+          const secondResult = await pool.query('SELECT x FROM ' + schemaName + '.TEST_TABLE ORDER BY x');
+
+          expect(firstResult.getRows()).toHaveLength(2000);
+          expect(secondResult.getRows()).toHaveLength(2000);
+        } finally {
+          await pool.drain();
+          await pool.clear();
+          await driver.close();
+        }
       });
 
       it('Cancel long running query', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exasol/exasol-driver-ts",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Exasol SQL Driver",
   "scripts": {
     "audit": "npm run audit:prod && npm run audit:full",

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -22,7 +22,7 @@ export type Commands =
   | ColumnsCommand
   | TablesCommand
   | DisconnectCommand;
-export type CommandsNoResult = AbortQueryCommand | CloseResultSetCommand;
+export type CommandsNoResult = AbortQueryCommand;
 
 export abstract class Command {
   abstract command: string;

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -10,6 +10,7 @@ export type Commands =
   | SQLBatchCommand
   | SQLSingleCommand
   | FetchCommand
+  | CloseResultSetCommand
   | CreatePreparedStatementCommand
   | ClosePreparedStatementCommand
   | ExecutePreparedStatementCommand
@@ -103,6 +104,7 @@ export class CreatePreparedStatementCommand extends Command {
   }
 }
 
+/** https://github.com/exasol/websocket-api/blob/master/docs/commands/closeResultSetV1.md */
 export class CloseResultSetCommand extends Command {
   command = 'closeResultSet';
   resultSetHandles: number[];
@@ -158,6 +160,7 @@ export class DisconnectCommand extends Command {
   command = 'disconnect';
 }
 
+/** https://github.com/exasol/websocket-api/blob/master/docs/commands/abortQueryV1.md */
 export class AbortQueryCommand extends Command {
   command = 'abortQuery';
 }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -34,7 +34,7 @@ export const fetchData = async (
   fetchSizeBytes: number,
   resultSetMaxRows?: number
 ): Promise<SQLResponse<SQLQueriesResponse>> => {
-  // [impl->dsn~runtime-query-execution~2]
+  // [impl->dsn~runtime-query-execution~3]
   const batchResponse = rawData.responseData;
 
   for (let index = 0; index < (batchResponse?.numResults ?? 0); index++) {
@@ -55,7 +55,7 @@ export const fetchData = async (
 
       logger.debug('[WebSQL]: Closing ResultSet', response.resultSet.resultSetHandle);
       if (response.resultSet.resultSetHandle) {
-        connection.sendCommandWithNoResult(new CloseResultSetCommand([response.resultSet.resultSetHandle]));
+        await connection.sendCommand(new CloseResultSetCommand([response.resultSet.resultSetHandle]));
       }
 
       logger.debug('[WebSQL]: Loaded all data');
@@ -77,7 +77,7 @@ const fetchMoreData = async (
   fetchSizeBytes: number,
   logger: ILogger
 ): Promise<ResultSet> => {
-  // [impl->dsn~runtime-query-execution~2]
+  // [impl->dsn~runtime-query-execution~3]
   logger.debug('[WebSQL]: fetchMoreData:', fetchedRows, expectedRows);
   if (fetchedRows < expectedRows && resultSet.resultSetHandle) {
     await sendFetchCommand(resultSet.resultSetHandle, fetchedRows, connection, fetchSizeBytes).then(async (fetchResponse) => {

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -55,7 +55,11 @@ export const fetchData = async (
 
       logger.debug('[WebSQL]: Closing ResultSet', response.resultSet.resultSetHandle);
       if (response.resultSet.resultSetHandle) {
-        await connection.sendCommand(new CloseResultSetCommand([response.resultSet.resultSetHandle]));
+        try {
+          await connection.sendCommand(new CloseResultSetCommand([response.resultSet.resultSetHandle]));
+        } catch (error) {
+          logger.warn('[WebSQL]: Closing ResultSet failed', error);
+        }
       }
 
       logger.debug('[WebSQL]: Loaded all data');

--- a/src/lib/mock-socket.ts
+++ b/src/lib/mock-socket.ts
@@ -44,9 +44,10 @@ export class MockExaWebSocket implements ExaWebsocket {
       case 'fetch':
         return { numRows: 1, data: [[2]] };
       case 'abortQuery':
-      case 'closeResultSet':
         // No response expected
         return undefined;
+      case 'closeResultSet':
+        return { "status": "ok" };
       default:
         throw new Error(`MockExaWebSocket: No mock response defined for command '${command.command}'.`);
     }

--- a/src/lib/sql-client.spec.node.ts
+++ b/src/lib/sql-client.spec.node.ts
@@ -42,7 +42,7 @@ describe('sqlClient', () => {
   });
 
   describe('query', () => {
-    // [utest->dsn~runtime-query-execution~2]
+    // [utest->dsn~runtime-query-execution~3]
     it('should result set', async () => {
       const connectPromise = driver.connect();
       mockSocketFactory.mockSocket.simulateOpen();
@@ -57,6 +57,21 @@ describe('sqlClient', () => {
       expect(mockSocketFactory.mockSocket.sentCommands).toContainEqual({
         command: 'execute',
         sqlText: 'select 1',
+      });
+    });
+
+    it('should consume the result set close response before reusing the connection', async () => {
+      const connectPromise = driver.connect();
+      mockSocketFactory.mockSocket.simulateOpen();
+      await connectPromise;
+
+      await driver.query('select with multiple rows');
+      const result = await driver.query('select 1');
+
+      expect(result.getRows()).toStrictEqual([{ A: 1 }]);
+      expect(mockSocketFactory.mockSocket.sentCommands).toContainEqual({
+        command: 'closeResultSet',
+        resultSetHandles: [17],
       });
     });
 

--- a/src/lib/sql-client.spec.node.ts
+++ b/src/lib/sql-client.spec.node.ts
@@ -75,6 +75,31 @@ describe('sqlClient', () => {
       });
     });
 
+    it('should return fetched rows when closing the result set fails', async () => {
+      const connectPromise = driver.connect();
+      mockSocketFactory.mockSocket.simulateOpen();
+      await connectPromise;
+
+      const originalSend = mockSocketFactory.mockSocket.send.bind(mockSocketFactory.mockSocket);
+      mockSocketFactory.mockSocket.send = (data: string | Uint8Array) => {
+        const command = JSON.parse(data.toString());
+        if (command.command === 'closeResultSet') {
+          mockSocketFactory.mockSocket.sentCommands.push(command);
+          setTimeout(() => {
+            mockSocketFactory.mockSocket.callOnMessage({
+              data: JSON.stringify({ status: 'error' }),
+            });
+          }, 0);
+          return;
+        }
+        originalSend(data);
+      };
+
+      const result = await driver.query('select with multiple rows');
+
+      expect(result.getRows()).toStrictEqual([{ A: 1 }, { A: 2 }]);
+    });
+
     // [utest->dsn~runtime-query-fetch-size~1]
     it('should use the configured fetch size in fetch commands', async () => {
       driver = new ExasolDriver(mockSocketFactory.factory, { accessToken: 'access-token', fetchSize: 42 });

--- a/src/lib/sql-client.ts
+++ b/src/lib/sql-client.ts
@@ -257,7 +257,7 @@ export class ExasolDriver implements IExasolDriver {
     getCancel?: CetCancelFunction | undefined,
     responseType?: 'default' | 'raw' | undefined,
   ): Promise<QueryResult | SQLResponse<SQLQueriesResponse>> {
-    // [impl->dsn~runtime-query-execution~2]
+    // [impl->dsn~runtime-query-execution~3]
     // [impl->dsn~runtime-raw-response-execution~1]
     const connection = await this.acquire();
     return connection


### PR DESCRIPTION
fix #82